### PR TITLE
favor assertions over runtime checks

### DIFF
--- a/src/main/java/org/mfusco/loom/experiments/LoomDeadlockMain.java
+++ b/src/main/java/org/mfusco/loom/experiments/LoomDeadlockMain.java
@@ -18,9 +18,12 @@ public class LoomDeadlockMain {
             // I/O thread create a v thread on itself
             Thread vThread = vThreadFactory.newThread(() -> {
                 eventLoop.execute(() -> {
-                    if (lockAcquired.join()) doWithLock(lock);
+                    assert lock.isLocked();
+                    doWithLock(lock);
                 });
-                if (lockAcquired.join()) doWithLock(lock);
+                lockAcquired.join();
+                assert lock.isLocked();
+                doWithLock(lock);
             });
             vThread.start();
         });


### PR DESCRIPTION
They can be changed into actual checks that lead to experiment failures, given that are not assumptions 
that can make the code to perform different decisions to the existing control flow